### PR TITLE
Fix detection thread not starting at second SdkInit

### DIFF
--- a/sdk_core/device_manager.cpp
+++ b/sdk_core/device_manager.cpp
@@ -96,7 +96,6 @@ bool DeviceManager::Init(const std::string& host_ip, const LivoxLidarLoggerCfgIn
   }
 
   detection_thread_ = std::make_shared<std::thread>(&DeviceManager::DetectionLidars, this);
-  is_stop_detection_.store(false);
   return true;
 }
 
@@ -425,6 +424,7 @@ bool DeviceManager::CreateDataSocketAndAddDelegate(const std::string& host_ip, c
 }
 
 void DeviceManager::DetectionLidars() {
+  is_stop_detection_.store(false);
   while (!is_stop_detection_) {
     Detection();
     std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
When uninitializing and initializing again, the device detection thread doesn't start properly (depends on the platform, undefined behaviour).
This fixes the issue.
The bug is reproducible by looping the livox_lidar_quick_start sample: without my fix it only works the first iteration (on Windows, but works on Linux...), with my fix it works properly.