### PR TITLE
fixed build errors for arch linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ if (CMAKE_CROSSCOMPILING)
 endif()
 
 if (UNIX)
+	set(CMAKE_CXX_STANDARD 20)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -std=gnu++0x")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=gnu++0x")
 endif(UNIX)
 
 add_subdirectory(sdk_core)

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 namespace livox {
 namespace lidar {


### PR DESCRIPTION
Hi, I had some issues compiling this library on arch linux. I modified the following files and compiles perfectly fine.

```
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ if (CMAKE_CROSSCOMPILING)
 endif()
 
 if (UNIX)
+       set(CMAKE_CXX_STANDARD 20)
        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -std=gnu++0x")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=gnu++0x")
 endif(UNIX)
```

and also the logger handler 

```
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
```