### PR TITLE
Livox-SDK: fix unallocated sdk_framework_cfg_ptr_

### DIFF
--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <vector>
 #include <atomic>
+#include <cstdint>
 
 #include "livox_lidar_def.h"
 

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -83,7 +83,7 @@ typedef struct {
 } LivoxLidarLoggerCfg;
 
 typedef struct {
-  bool master_sdk;
+  bool master_sdk = true;
 } LivoxLidarSdkFrameworkCfg;
 
 typedef enum {

--- a/sdk_core/device_manager.cpp
+++ b/sdk_core/device_manager.cpp
@@ -44,7 +44,7 @@ namespace livox {
 namespace lidar {
 
 DeviceManager::DeviceManager()
-    : sdk_framework_cfg_ptr_(nullptr),
+    : sdk_framework_cfg_ptr_(new LivoxLidarSdkFrameworkCfg()),
       lidars_cfg_ptr_(nullptr),
       custom_lidars_cfg_ptr_(nullptr),
       lidar_logger_cfg_ptr_(nullptr),

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 namespace livox {
 namespace lidar {


### PR DESCRIPTION
In DeviceManager, the Init without config path does not allocate the LivoxLidarSdkFrameworkCfg, resulting in a segfault when the callbacks try to check the master_sdk param. Set it by default to true when the initialization is done using the host IP.

```
LivoxLidarSdkInit(nullptr, "192.168.1.200")
```