### PR TITLE
feat:Converts to ros2 functional packages without having to install a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(livox_sdk2)
 
 set(CMAKE_CXX_STANDARD 11)
+find_package(ament_cmake REQUIRED)
 
 message(STATUS "main project dir: " ${PROJECT_SOURCE_DIR})
 
@@ -18,3 +19,5 @@ endif(UNIX)
 
 add_subdirectory(sdk_core)
 add_subdirectory(samples)
+
+ament_package()

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>livox_sdk2</name>
+  <version>1.0.0</version>
+  <description>The ROS device driver for Livox 3D LiDARs, for ROS2</description>
+  <maintainer email="dev@livoxtech.com">feng</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+ 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## settled
- [x] `mid360*2` and `had*1` multiple LIDAR test passes
- [x] `Livox-SDK2` `Fork` latest commit：817136e7cf9aa6a22de868c7a5b518ef170197a8

## Functions realized
- No need to install `livox_SDK2` manually:`Livox-SDK2` modified to ros2 functional package

![image](https://github.com/Livox-SDK/Livox-SDK2/assets/46778435/6f6e8713-b096-4d52-a869-7962cf486a4c)


