### PR TITLE
Fix build error with GCC 13.2.0

### DIFF
--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -25,7 +25,7 @@
 #ifndef LIVOX_DEFINE_H_
 #define LIVOX_DEFINE_H_
 
-#include <stdio.h>
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <functional>

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_FILE_MANAGER_
 #define LIVOX_FILE_MANAGER_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Hi, When building with GCC (Ubuntu 13.2.0-23ubuntu4) 13.2.0, the following error occurs:

```
Livox-SDK2/sdk_core/comm/define.h:235:8: error: ‘uint8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
```

The error appears to be due to a missing include for the <cstdint> header.
This PR adds the necessary include to fix the issue.