### PR TITLE
Fix some 3rdparty and network bind setting for MacOS 15.1.1 compatility

### DIFF
--- a/3rdparty/FastCRC/FastCRC.h
+++ b/3rdparty/FastCRC/FastCRC.h
@@ -129,7 +129,7 @@ public:
 #endif
 private:
 #if CRC_SW
-  uint16_t seed;
+[[maybe_unused]]  uint16_t seed;
 #else
   uint16_t update(const uint8_t *data, const size_t datalen);
 #endif
@@ -159,7 +159,7 @@ public:
 #endif
 private:
 #if CRC_SW
-  uint16_t seed;
+[[maybe_unused]] uint16_t seed;
 #else
   uint16_t update(const uint8_t *data, const size_t datalen);
 #endif

--- a/3rdparty/rapidjson/document.h
+++ b/3rdparty/rapidjson/document.h
@@ -31,13 +31,18 @@
 
 RAPIDJSON_DIAG_PUSH
 #ifdef __clang__
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(switch - enum)
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#endif
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #elif defined(_MSC_VER)
-RAPIDJSON_DIAG_OFF(4127)  // conditional expression is constant
-RAPIDJSON_DIAG_OFF(
-    4244)  // conversion from kXxxFlags to 'uint16_t', possible loss of data
+RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
+RAPIDJSON_DIAG_OFF(4244) // conversion from kXxxFlags to 'uint16_t', possible loss of data
 #endif
 
 #ifdef __GNUC__

--- a/3rdparty/rapidjson/encodedstream.h
+++ b/3rdparty/rapidjson/encodedstream.h
@@ -29,7 +29,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/error/en.h
+++ b/3rdparty/rapidjson/error/en.h
@@ -23,8 +23,12 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(switch - enum)
-RAPIDJSON_DIAG_OFF(covered - switch - default)
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
+#if __has_warning("-Wcovered-switch-default")
+RAPIDJSON_DIAG_OFF(covered-switch-default)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/error/error.h
+++ b/3rdparty/rapidjson/error/error.h
@@ -23,7 +23,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 /*! \file error.h */

--- a/3rdparty/rapidjson/filereadstream.h
+++ b/3rdparty/rapidjson/filereadstream.h
@@ -24,9 +24,15 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(unreachable - code)
-RAPIDJSON_DIAG_OFF(missing - noreturn)
+#endif
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
+#if __has_warning("-Wmissing-noreturn")
+RAPIDJSON_DIAG_OFF(missing-noreturn)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/filewritestream.h
+++ b/3rdparty/rapidjson/filewritestream.h
@@ -24,7 +24,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(unreachable - code)
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/internal/diyfp.h
+++ b/3rdparty/rapidjson/internal/diyfp.h
@@ -42,7 +42,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 struct DiyFp {

--- a/3rdparty/rapidjson/internal/dtoa.h
+++ b/3rdparty/rapidjson/internal/dtoa.h
@@ -33,7 +33,7 @@ namespace internal {
 #ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
-RAPIDJSON_DIAG_OFF(array - bounds)  // some gcc versions generate wrong warnings
+RAPIDJSON_DIAG_OFF(array-bounds)  // some gcc versions generate wrong warnings
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59124
 #endif
 

--- a/3rdparty/rapidjson/internal/regex.h
+++ b/3rdparty/rapidjson/internal/regex.h
@@ -25,8 +25,12 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(switch - enum)
+#endif
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4512)  // assignment operator could not be generated

--- a/3rdparty/rapidjson/internal/stack.h
+++ b/3rdparty/rapidjson/internal/stack.h
@@ -25,7 +25,9 @@
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/internal/swap.h
+++ b/3rdparty/rapidjson/internal/swap.h
@@ -23,7 +23,9 @@
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/istreamwrapper.h
+++ b/3rdparty/rapidjson/istreamwrapper.h
@@ -25,7 +25,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4351)  // new behavior: elements of array 'array' will be

--- a/3rdparty/rapidjson/memorystream.h
+++ b/3rdparty/rapidjson/memorystream.h
@@ -23,8 +23,12 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(unreachable - code)
-RAPIDJSON_DIAG_OFF(missing - noreturn)
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
+#if __has_warning("-Wmissing-noreturn")
+RAPIDJSON_DIAG_OFF(missing-noreturn)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/ostreamwrapper.h
+++ b/3rdparty/rapidjson/ostreamwrapper.h
@@ -24,7 +24,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/pointer.h
+++ b/3rdparty/rapidjson/pointer.h
@@ -24,7 +24,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(switch - enum)
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4512)  // assignment operator could not be generated

--- a/3rdparty/rapidjson/prettywriter.h
+++ b/3rdparty/rapidjson/prettywriter.h
@@ -28,7 +28,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/reader.h
+++ b/3rdparty/rapidjson/reader.h
@@ -44,9 +44,15 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(old - style - cast)
+#if __has_warning("-Wold-style-cast")
+RAPIDJSON_DIAG_OFF(old-style-cast)
+#endif
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(switch - enum)
+#endif
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127)  // conditional expression is constant

--- a/3rdparty/rapidjson/schema.h
+++ b/3rdparty/rapidjson/schema.h
@@ -65,10 +65,18 @@ RAPIDJSON_DIAG_OFF(effc++)
 #endif
 
 #ifdef __clang__
-RAPIDJSON_DIAG_OFF(weak - vtables)
-RAPIDJSON_DIAG_OFF(exit - time - destructors)
-RAPIDJSON_DIAG_OFF(c++ 98 - compat - pedantic)
-RAPIDJSON_DIAG_OFF(variadic - macros)
+#if __has_warning("-Wweak-vtables")
+RAPIDJSON_DIAG_OFF(weak-vtables)
+#endif
+#if __has_warning("-Wexit-time-destructors")
+RAPIDJSON_DIAG_OFF(exit-time-destructors)
+#endif
+#if __has_warning("-Wc++98-compat-pedantic")
+RAPIDJSON_DIAG_OFF(c++98-compat-pedantic)
+#endif
+#if __has_warning("-Wvariadic-macros")
+RAPIDJSON_DIAG_OFF(variadic-macros)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_OFF(4512)  // assignment operator could not be generated
 #endif

--- a/3rdparty/rapidjson/stringbuffer.h
+++ b/3rdparty/rapidjson/stringbuffer.h
@@ -30,7 +30,9 @@
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/writer.h
+++ b/3rdparty/rapidjson/writer.h
@@ -43,9 +43,15 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(unreachable - code)
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#endif
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127)  // conditional expression is constant

--- a/3rdparty/spdlog/spdlog/fmt/bundled/format.h
+++ b/3rdparty/spdlog/spdlog/fmt/bundled/format.h
@@ -404,7 +404,12 @@ void basic_buffer<T>::append(const U *begin, const U *end) {
 // type in this mode. If this is the case __cpp_char8_t will be defined.
 #if !defined(__cpp_char8_t)
 // A UTF-8 code unit type.
-enum char8_t: unsigned char {};
+// NOTE: originally `enum char8_t: unsigned char {}`. Newer libc++ leaves the
+// primary template `std::char_traits` undefined, so instantiating
+// `basic_string_view<fmt::char8_t>` (the enum) fails. Aliasing to `char` keeps
+// `basic_string_view<char>` machinery happy without breaking call sites
+// that take/return `const char8_t*`.
+using char8_t = char;
 #endif
 
 // A UTF-8 string view.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CMAKE_CROSSCOMPILING)
 		"PLEASE_FILL_OUT-FAILED_TO_RUN"
 		CACHE STRING "Result from TRY_RUN" FORCE)
 endif()
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-value -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-deprecated-declarations")
 if (UNIX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 endif(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(livox_sdk2)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 message(STATUS "main project dir: " ${PROJECT_SOURCE_DIR})
 
@@ -11,7 +11,7 @@ if (CMAKE_CROSSCOMPILING)
 		"PLEASE_FILL_OUT-FAILED_TO_RUN"
 		CACHE STRING "Result from TRY_RUN" FORCE)
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-value -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-value -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-deprecated-declarations -Wno-error=delete-non-abstract-non-virtual-dtor")
 if (UNIX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 endif(UNIX)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(livox_sdk2)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 message(STATUS "main project dir: " ${PROJECT_SOURCE_DIR})
 

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -137,7 +137,7 @@ typedef struct {
   uint16_t cmd_port;
 } DetectionData;
 
-typedef struct {
+typedef  struct ViewDevice{
   uint32_t handle;
   uint16_t cmd_port;
   uint8_t dev_type;

--- a/sdk_core/comm/sdk_protocol.cpp
+++ b/sdk_core/comm/sdk_protocol.cpp
@@ -31,8 +31,8 @@ namespace lidar {
 
 const uint8_t kSdkProtocolSof = 0xAA;
 const uint8_t kSdkVer = 0;
-const uint32_t kSdkPacketCrcSize = 4;          // crc32
-const uint32_t kSdkPacketPreambleCrcSize = 2;  // crc16
+[[maybe_unused]]const uint32_t kSdkPacketCrcSize = 4;          // crc32
+[[maybe_unused]]const uint32_t kSdkPacketPreambleCrcSize = 2;  // crc16
 
 SdkProtocol::SdkProtocol() {}
 

--- a/sdk_core/command_handler/general_command_handler.h
+++ b/sdk_core/command_handler/general_command_handler.h
@@ -63,6 +63,7 @@ class GeneralCommandHandler : public noncopyable {
   GeneralCommandHandler(const GeneralCommandHandler& other) = delete;
   GeneralCommandHandler& operator=(const GeneralCommandHandler& other) = delete;
  public:
+ 
   ~GeneralCommandHandler();
   void Destory();
   static GeneralCommandHandler& GetInstance();

--- a/sdk_core/command_handler/hap_command_handler.h
+++ b/sdk_core/command_handler/hap_command_handler.h
@@ -48,7 +48,7 @@ namespace lidar {
 class HapCommandHandler : public CommandHandler {
  public:
   HapCommandHandler(DeviceManager* device_manager);
-  ~HapCommandHandler() {}
+  virtual ~HapCommandHandler() {}
   static HapCommandHandler& GetInstance();
   virtual bool Init(bool is_view);
 
@@ -77,6 +77,8 @@ class HapCommandHandler : public CommandHandler {
   bool IsStatusException(const Command &command);
   void QueryDiagnosisInfo(uint32_t handle);
   void OnLidarInfoChange(const Command &command);
+
+  
  private:
   std::unique_ptr<CommPort> comm_port_;
   std::mutex device_mutex_;

--- a/sdk_core/command_handler/mid360_command_handler.h
+++ b/sdk_core/command_handler/mid360_command_handler.h
@@ -48,7 +48,7 @@ namespace lidar {
 class Mid360CommandHandler : public CommandHandler {
  public:
   Mid360CommandHandler(DeviceManager* device_manager);
-  ~Mid360CommandHandler() {}
+  virtual ~Mid360CommandHandler() {}
   virtual bool Init(bool is_view);
 
   virtual bool Init(const std::map<uint32_t, LivoxLidarCfg>& custom_lidars_cfg_map);
@@ -60,6 +60,8 @@ class Mid360CommandHandler : public CommandHandler {
 
   static void UpdateLidarCallback(livox_status status, uint32_t handle, LivoxLidarAsyncControlResponse *response, void *client_data);
   void AddDevice(const uint32_t handle);
+  
+
  private:
   void SetCustomLidar(const uint32_t handle, const uint16_t lidar_cmd_port, const LivoxLidarCfg& lidar_cfg);
   void SetViewLidar(const ViewLidarIpInfo& view_lidar_info);

--- a/sdk_core/data_handler/data_handler.cpp
+++ b/sdk_core/data_handler/data_handler.cpp
@@ -31,7 +31,7 @@ namespace livox {
 
 namespace lidar {
 
-static const size_t kPrefixDataSize = 18;
+[[maybe_unused]]static const size_t kPrefixDataSize = 18;
 
 DataHandler::DataHandler()
     : point_data_callbacks_(nullptr),

--- a/sdk_core/upgrade/firmware.h
+++ b/sdk_core/upgrade/firmware.h
@@ -118,8 +118,8 @@ class Firmware {
   ~Firmware();
   bool Open(const char *firmware_path);
   void Close();
-
-  const uint32_t FirmwarePackageVersion() const { return header_.file_version; }
+            
+            uint32_t FirmwarePackageVersion() const { return header_.file_version; }
 
 
   LivoxEncryptFirmwareHeader header_;


### PR DESCRIPTION
I eager to use Mid-360 in MacOS and finally I achieved it !!

Some codes are untidy. Please check these changes.

The change summery is below. (created by copilot)
- This pull request includes several changes to the `3rdparty/FastCRC` and `3rdparty/rapidjson` libraries. The primary focus is on improving compatibility with various compilers by adding conditional checks for specific warnings and marking unused variables.


Changes in `3rdparty/FastCRC`:

* Marked `seed` variable as `[[maybe_unused]]` in `class FastCRC14` and `class FastCRC16` to avoid unused variable warnings. [[1]](diffhunk://#diff-6003765dedee18de61622da58cff80a93011da64b60618257cf9f17edb5c08a6L132-R132) [[2]](diffhunk://#diff-6003765dedee18de61622da58cff80a93011da64b60618257cf9f17edb5c08a6L162-R162)

Changes in `3rdparty/rapidjson`:

* Added conditional checks for various warnings (e.g., `-Wpadded`, `-Wswitch-enum`, `-Wc++98-compat`) and disabled them if present in multiple files to improve compatibility with Clang. [[1]](diffhunk://#diff-f59e584ac52b8c1bc433c223ddd1fdb03fad09f6234beaf1fd559c382371ae7fR34-R45) [[2]](diffhunk://#diff-274a6db9579b3d19a17fc5701ba0798c74786d2439a61cf2dd5aaf5f11fc6eefR32-R35) [[3]](diffhunk://#diff-3c2bb850e9711df6a45dd1507f2712a11c8b29b236aa77efaccc637406fc6b57R26-R32) [[4]](diffhunk://#diff-50d12a5794b25b09580159bb68738bc4fa58c07fecc237ec0ba86463c052aee9R26-R29) [[5]](diffhunk://#diff-2eb9b9a140ca6875501a1140c14ebdc1fba7d2f2a9aaf4be72944311467ad7d3R27-R36) [[6]](diffhunk://#diff-36feb0883bc26593085f33ca419f8b136e9bb9b904e0e89a475517cc71fd9570R27-R30) [[7]](diffhunk://#diff-8fd7e72fa989a8147bdb5802fe5c9054de045b5d1a1186993402ee36e0b3aa60R45-R48) [[8]](diffhunk://#diff-4ce970de333b4a023afa5f61a9b2d7f19370188d9729033015187c7d73fee466R28-R33) [[9]](diffhunk://#diff-4950d9fa7edd6555448ab0108be53a86b50a279f16e481b626e6ca848789e0eaR28-R31) [[10]](diffhunk://#diff-31519dbcb16cd356a587675d5b28ed91e30abec28f168b4915203af86b4ec7bfR26-R29) [[11]](diffhunk://#diff-76e87a730cf37616868d88e53cf6c10153383d64285f2bef2eead6d645482e86R28-R30) [[12]](diffhunk://#diff-8f8da8d009ef3c6740fed79d4e8c2fb80d470455bda4815a2856f5d312e44f6fR26-R32) [[13]](diffhunk://#diff-d5969cc1132f1af76b8014f6b2f36eae7101c00c9e76cca524b9db6fceafd7a1R27-R30) [[14]](diffhunk://#diff-0c43e8b0e01ad591c877c35f859e036d69453fd4e69cc2f0c9c0bc6d8780a415R27-R29) [[15]](diffhunk://#diff-5f27294e6306b1ea2022668015402ba289344e340bff79735878b317c4be98e5R31-R34) [[16]](diffhunk://#diff-3619c89b25243e00f9e47274a04f7a00e2a159090ea6bc406763ffca4d8999aaR47-R55) [[17]](diffhunk://#diff-a99dac044702c3d4ca21e48a24957721108c0d745494b313fee8358d7ea232bfR68-R79) [[18]](diffhunk://#diff-b6cde8759415b3e8d231d4b0f9cf5ad01cf60c46efed62fd291e6d64531c735eR33-R36)