### PR TITLE
Add cmake installation instructions

### DIFF
--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -52,14 +52,16 @@ set(LIVOX_PUBLIC_INCLUDE_DIR
 target_include_directories(
         ${SDK_LIBRARY_STATIC}
         PUBLIC
-        ${LIVOX_PUBLIC_INCLUDE_DIR}
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        $<INSTALL_INTERFACE:include>
         PRIVATE
         ${LIVOX_PRIVATE_INCLUDE_DIR}
         )        
 target_include_directories(
         ${SDK_LIBRARY_SHARED}
         PUBLIC
-        ${LIVOX_PUBLIC_INCLUDE_DIR}
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        $<INSTALL_INTERFACE:include>
         PRIVATE
         ${LIVOX_PRIVATE_INCLUDE_DIR}
         )
@@ -138,6 +140,14 @@ target_sources(${SDK_LIBRARY_SHARED}
         )
 
 install(TARGETS ${SDK_LIBRARY_STATIC} ${SDK_LIBRARY_SHARED}
-        PUBLIC_HEADER DESTINATION include
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+        EXPORT ${PROJECT_NAME}-config
+        RUNTIME DESTINATION lib
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+install(EXPORT ${PROJECT_NAME}-config
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION lib/cmake/${PROJECT_NAME})
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+        DESTINATION include)

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -25,7 +25,7 @@
 #ifndef LIVOX_DEFINE_H_
 #define LIVOX_DEFINE_H_
 
-#include <stdio.h>
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <functional>

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_FILE_MANAGER_
 #define LIVOX_FILE_MANAGER_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
commit 1: Fix compilation errors, same as pr #83 
commit2: Add cmake installation instructions so that other projects can use similar
```cmake
find_package(livox_sdk2 REQUIRED CONFIG)
target_link_libraries(${PROJECT_NAME} PRIVATE livox_sdk2::livox_lidar_sdk_shared)
```