### PR TITLE
Fix compile errors on ubuntu 24.04 (gcc 13.3.0)

### DIFF
--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -26,6 +26,7 @@
 #define LIVOX_DEFINE_H_
 
 #include <stdio.h>
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <functional>
@@ -232,9 +233,9 @@ typedef struct {
 
 typedef struct {
   std::string   sn;
-  std::uint8_t  dev_type;
+  uint8_t  dev_type;
   std::string   lidar_ip;
-  std::uint16_t cmd_port;
+  uint16_t cmd_port;
 } LidarDeviceInfo;
 
 typedef struct {
@@ -339,7 +340,7 @@ typedef struct {
 } LivoxLidarDebugPointCloudRequest;
 
 typedef struct {
-  enum class SyncTimeType : std::uint8_t {
+  enum class SyncTimeType : uint8_t {
     kRmcSyncTime = 2,
   } type;
   uint64_t ns;

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_FILE_MANAGER_
 #define LIVOX_FILE_MANAGER_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
I'm attempting to deploy Livox lidars on ROS 2 Jazzy (ubuntu 24.04). From my experience with ROS-1 noetic and ROS-2 humble, installing this SDK is a prerequisite. 

However, I stumbled across a couple of std::uint8_t related errors and inconsistencies that didn't previously cause the build to fail, but now (using gcc 13.3) do.

I fixed the inconsistencies in favor of uint8_t (without std::) and added #include <cstdint> explicitly to provide the type declarations (required for uint64_t in file_manager.h).