### PR TITLE
fix for unit_xx error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 project(livox_sdk2)
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 project(livox_sdk2)
 

--- a/samples/debug_point_cloud/CMakeLists.txt
+++ b/samples/debug_point_cloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(DEMO_NAME debug_point_cloud)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/lidar_cmd_observer/CMakeLists.txt
+++ b/samples/lidar_cmd_observer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(DEMO_NAME lidar_cmd_observer)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_quick_start/CMakeLists.txt
+++ b/samples/livox_lidar_quick_start/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(DEMO_NAME livox_lidar_quick_start)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
+++ b/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(DEMO_NAME livox_lidar_rmc_time_sync)
 if (WIN32)

--- a/samples/logger/CMakeLists.txt
+++ b/samples/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(DEMO_NAME logger)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/multi_lidars_upgrade/CMakeLists.txt
+++ b/samples/multi_lidars_upgrade/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(DEMO_NAME multi_lidars_upgrade)
 add_executable(${DEMO_NAME} main.cpp)

--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(SDK_LIBRARY_STATIC livox_lidar_sdk_static)
 set(SDK_LIBRARY_SHARED livox_lidar_sdk_shared)

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <vector>
 #include <atomic>
+#include <cstdint>
 
 #include "livox_lidar_def.h"
 

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 namespace livox {
 namespace lidar {


### PR DESCRIPTION
While trying to compile as per readme, the following error occurs

```
Livox-SDK2/sdk_core/comm/define.h:235:8: error: ‘uint8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  235 |   std::uint8_t  dev_type;
      |        ^~~~~~~
      |        wint_t

```
This has been fixed along with CMake < 3.5 warning