### PR TITLE
Fix GCC 13 build issues (cstdint include, char8_t warning)

### DIFF
--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <vector>
 #include <atomic>
+#include <cstdint>
 
 #include "livox_lidar_def.h"
 

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 namespace livox {
 namespace lidar {

--- a/sdk_core/parse_cfg_file.h
+++ b/sdk_core/parse_cfg_file.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 namespace livox {
 namespace lidar {


### PR DESCRIPTION
Added necessary includes due to this article:
https://www.gnu.org/software/gcc/gcc-13/porting_to.html

Ubuntu 24 comes with GCC 13. Since GCC 13 the C++ Standard Library headers have been changed.