### PR TITLE
Fix: Suppress unused private field warning on macOS

### DIFF
--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -30,13 +30,13 @@ endif (WIN32)
 
 target_compile_options(${SDK_LIBRARY_STATIC}
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>#-Wno-c++11-long-long>
-        PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Wno-unused-private-field -Wno-c++11-long-long>
         PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
         )
 
 target_compile_options(${SDK_LIBRARY_SHARED}
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>#-Wno-c++11-long-long>
-        PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Wno-unused-private-field -Wno-c++11-long-long>
         PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
         )
 


### PR DESCRIPTION
This pull request resolves a build failure on macOS caused by the compiler's `-Werror` flag and the `-Wunused-private-field` warning.

This fix modifies the `target_compile_options` to specifically suppress the `-Wunused-private-field` warning for the `AppleClang` compiler. This allows the build to pass successfully while retaining other important warnings enabled by the `-Wall` flag, ensuring continued code quality checks