### PR TITLE
Modernize CMake configuration and upgrade minimum version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(livox_sdk2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,12 @@ cmake_minimum_required(VERSION 3.10)
 project(livox_sdk2)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Threads REQUIRED)
 
 message(STATUS "main project dir: " ${PROJECT_SOURCE_DIR})
-
-if (CMAKE_CROSSCOMPILING)
-	set(THREADS_PTHREAD_ARG
-		"PLEASE_FILL_OUT-FAILED_TO_RUN"
-		CACHE STRING "Result from TRY_RUN" FORCE)
-endif()
-
-if (UNIX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-endif(UNIX)
 
 add_subdirectory(sdk_core)
 add_subdirectory(samples)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(livox_sdk2)
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,21 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(livox_sdk2)
-
-set(CMAKE_CXX_STANDARD 11)
-
-message(STATUS "main project dir: " ${PROJECT_SOURCE_DIR})
-
-if (CMAKE_CROSSCOMPILING)
-	set(THREADS_PTHREAD_ARG
-		"PLEASE_FILL_OUT-FAILED_TO_RUN"
-		CACHE STRING "Result from TRY_RUN" FORCE)
-endif()
-
-if (UNIX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-endif(UNIX)
-
 add_subdirectory(livox_lidar_quick_start)
 add_subdirectory(multi_lidars_upgrade)
 add_subdirectory(logger)

--- a/samples/debug_point_cloud/CMakeLists.txt
+++ b/samples/debug_point_cloud/CMakeLists.txt
@@ -3,7 +3,4 @@ cmake_minimum_required(VERSION 3.10)
 set(DEMO_NAME debug_point_cloud)
 add_executable(${DEMO_NAME} main.cpp)
 
-target_link_libraries(${DEMO_NAME}
-        PUBLIC
-        livox_lidar_sdk_static)
-
+target_link_libraries(${DEMO_NAME} PUBLIC livox_lidar_sdk_static)

--- a/samples/debug_point_cloud/CMakeLists.txt
+++ b/samples/debug_point_cloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME debug_point_cloud)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/lidar_cmd_observer/CMakeLists.txt
+++ b/samples/lidar_cmd_observer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME lidar_cmd_observer)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/lidar_cmd_observer/CMakeLists.txt
+++ b/samples/lidar_cmd_observer/CMakeLists.txt
@@ -3,13 +3,6 @@ cmake_minimum_required(VERSION 3.10)
 set(DEMO_NAME lidar_cmd_observer)
 add_executable(${DEMO_NAME} main.cpp)
 
-target_include_directories(
-        ${DEMO_NAME}
-        PRIVATE
-        ../../3rdparty/
-        )
+target_include_directories(${DEMO_NAME} PRIVATE ../../3rdparty/)
 
-target_link_libraries(${DEMO_NAME}
-        PUBLIC
-        livox_lidar_sdk_static
-				)
+target_link_libraries(${DEMO_NAME} PUBLIC livox_lidar_sdk_static)

--- a/samples/livox_lidar_quick_start/CMakeLists.txt
+++ b/samples/livox_lidar_quick_start/CMakeLists.txt
@@ -3,7 +3,4 @@ cmake_minimum_required(VERSION 3.10)
 set(DEMO_NAME livox_lidar_quick_start)
 add_executable(${DEMO_NAME} main.cpp)
 
-target_link_libraries(${DEMO_NAME}
-        PUBLIC
-        livox_lidar_sdk_static
-				)
+target_link_libraries(${DEMO_NAME} PUBLIC livox_lidar_sdk_static)

--- a/samples/livox_lidar_quick_start/CMakeLists.txt
+++ b/samples/livox_lidar_quick_start/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME livox_lidar_quick_start)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
+++ b/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME livox_lidar_rmc_time_sync)
 if (WIN32)

--- a/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
+++ b/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
@@ -1,13 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME livox_lidar_rmc_time_sync)
-if (WIN32)
+if(WIN32)
   add_executable(${DEMO_NAME} main.cpp win/synchro.cpp)
 elseif(UNIX)
   add_executable(${DEMO_NAME} main.cpp linux/synchro.cpp)
 endif()
 
-target_link_libraries(${DEMO_NAME}
-        PUBLIC
-        livox_lidar_sdk_static
-)
+target_link_libraries(${DEMO_NAME} PUBLIC livox_lidar_sdk_static)

--- a/samples/logger/CMakeLists.txt
+++ b/samples/logger/CMakeLists.txt
@@ -3,7 +3,4 @@ cmake_minimum_required(VERSION 3.10)
 set(DEMO_NAME logger)
 add_executable(${DEMO_NAME} main.cpp)
 
-target_link_libraries(${DEMO_NAME}
-        PUBLIC
-        livox_lidar_sdk_static)
-
+target_link_libraries(${DEMO_NAME} PUBLIC livox_lidar_sdk_static)

--- a/samples/logger/CMakeLists.txt
+++ b/samples/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME logger)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/multi_lidars_upgrade/CMakeLists.txt
+++ b/samples/multi_lidars_upgrade/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME multi_lidars_upgrade)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/multi_lidars_upgrade/CMakeLists.txt
+++ b/samples/multi_lidars_upgrade/CMakeLists.txt
@@ -3,7 +3,4 @@ cmake_minimum_required(VERSION 3.10)
 set(DEMO_NAME multi_lidars_upgrade)
 add_executable(${DEMO_NAME} main.cpp)
 
-target_link_libraries(${DEMO_NAME}
-        PUBLIC
-        livox_lidar_sdk_static
-        )
+target_link_libraries(${DEMO_NAME} PUBLIC livox_lidar_sdk_static)

--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(SDK_LIBRARY_STATIC livox_lidar_sdk_static)
 set(SDK_LIBRARY_SHARED livox_lidar_sdk_shared)

--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -9,135 +9,102 @@ add_library(${SDK_LIBRARY_SHARED} SHARED "")
 set(LIVOX_SDK_MAJOR_VERSION "0")
 set(LIVOX_SDK_MINOR_VERSION "0")
 set(LIVOX_SDK_PATCH_VERSION "2")
-set(LIVOX_SDK_VERSION_STRING "${LIVOX_SDK_MAJOR_VERSION}.${LIVOX_SDK_MINOR_VERSION}.${LIVOX_SDK_PATCH_VERSION}")
+set(LIVOX_SDK_VERSION_STRING
+    "${LIVOX_SDK_MAJOR_VERSION}.${LIVOX_SDK_MINOR_VERSION}.${LIVOX_SDK_PATCH_VERSION}"
+)
 
-set(LIVOX_API_HEADER
-        ../include/livox_lidar_def.h
-        ../include/livox_lidar_api.h
-        ../include/livox_lidar_cfg.h
-        )
+set(LIVOX_API_HEADER ../include/livox_lidar_def.h ../include/livox_lidar_api.h
+                     ../include/livox_lidar_cfg.h)
 
-set_target_properties(${SDK_LIBRARY_STATIC} #${SDK_LIBRARY_SHARED} 
-        PROPERTIES
-        PUBLIC_HEADER "${LIVOX_API_HEADER}"
-        )
+set_target_properties(${SDK_LIBRARY_STATIC} # ${SDK_LIBRARY_SHARED}
+                      PROPERTIES PUBLIC_HEADER "${LIVOX_API_HEADER}")
 
 if(WIN32)
   set(PLATFORM win)
 else(WIN32)
   set(PLATFORM unix)
-endif (WIN32)
+endif(WIN32)
 
-target_compile_options(${SDK_LIBRARY_STATIC}
-        PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>#-Wno-c++11-long-long>
-        PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
-        PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
-        )
+target_compile_options(
+  ${SDK_LIBRARY_STATIC}
+  PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall> # -Wno-c++11-long-long>
+  PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Werror
+          -Wno-c++11-long-long>
+  PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas -Wall -Werror
+          -Wno-c++11-long-long>)
 
-target_compile_options(${SDK_LIBRARY_SHARED}
-        PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>#-Wno-c++11-long-long>
-        PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
-        PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas -Wall -Werror -Wno-c++11-long-long>
-        )
+target_compile_options(
+  ${SDK_LIBRARY_SHARED}
+  PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall> # -Wno-c++11-long-long>
+  PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unknown-pragmas -Wall -Werror
+          -Wno-c++11-long-long>
+  PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas -Wall -Werror
+          -Wno-c++11-long-long>)
 
-set(LIVOX_PRIVATE_INCLUDE_DIR 
-        ../3rdparty 
-        ../3rdparty/spdlog 
-        .
-        )
-set(LIVOX_PUBLIC_INCLUDE_DIR 
-        ../include
-        )
+set(LIVOX_PRIVATE_INCLUDE_DIR ../3rdparty ../3rdparty/spdlog .)
+set(LIVOX_PUBLIC_INCLUDE_DIR ../include)
 
 target_include_directories(
-        ${SDK_LIBRARY_STATIC}
-        PUBLIC
-        ${LIVOX_PUBLIC_INCLUDE_DIR}
-        PRIVATE
-        ${LIVOX_PRIVATE_INCLUDE_DIR}
-        )        
+  ${SDK_LIBRARY_STATIC}
+  PUBLIC ${LIVOX_PUBLIC_INCLUDE_DIR}
+  PRIVATE ${LIVOX_PRIVATE_INCLUDE_DIR})
 target_include_directories(
-        ${SDK_LIBRARY_SHARED}
-        PUBLIC
-        ${LIVOX_PUBLIC_INCLUDE_DIR}
-        PRIVATE
-        ${LIVOX_PRIVATE_INCLUDE_DIR}
-        )
+  ${SDK_LIBRARY_SHARED}
+  PUBLIC ${LIVOX_PUBLIC_INCLUDE_DIR}
+  PRIVATE ${LIVOX_PRIVATE_INCLUDE_DIR})
 
-set(MAIN_SOURCES
-        device_manager.cpp
-        livox_lidar_sdk.cpp
-        params_check.cpp
-        parse_cfg_file.cpp
-        upgrade_manager.cpp
-        )
+set(MAIN_SOURCES device_manager.cpp livox_lidar_sdk.cpp params_check.cpp
+                 parse_cfg_file.cpp upgrade_manager.cpp)
 set(BASE_SOURCES
-        base/io_loop.cpp
-        base/thread_base.cpp
-        base/io_thread.cpp
-        base/logging.cpp
-        base/network/${PLATFORM}/network_util.cpp
-        base/multiple_io/multiple_io_base.cpp
-        base/multiple_io/multiple_io_epoll.cpp
-        base/multiple_io/multiple_io_poll.cpp
-        base/multiple_io/multiple_io_select.cpp
-        base/multiple_io/multiple_io_kqueue.cpp
-        base/wake_up/${PLATFORM}/wake_up_pipe.cpp
-        )
-set(COMM_SOURCES
-        comm/comm_port.cpp
-        comm/sdk_protocol.cpp
-        comm/generate_seq.cpp
-        )
-set(UPGRADE_SOURCES
-        upgrade_manager.cpp
-        upgrade/firmware.cpp
-        upgrade/livox_lidar_upgrader.cpp
-        )
+    base/io_loop.cpp
+    base/thread_base.cpp
+    base/io_thread.cpp
+    base/logging.cpp
+    base/network/${PLATFORM}/network_util.cpp
+    base/multiple_io/multiple_io_base.cpp
+    base/multiple_io/multiple_io_epoll.cpp
+    base/multiple_io/multiple_io_poll.cpp
+    base/multiple_io/multiple_io_select.cpp
+    base/multiple_io/multiple_io_kqueue.cpp
+    base/wake_up/${PLATFORM}/wake_up_pipe.cpp)
+set(COMM_SOURCES comm/comm_port.cpp comm/sdk_protocol.cpp comm/generate_seq.cpp)
+set(UPGRADE_SOURCES upgrade_manager.cpp upgrade/firmware.cpp
+                    upgrade/livox_lidar_upgrader.cpp)
 set(LOGGER_HANDLER_SOURCES
-        logger_handler/logger_manager.cpp
-        logger_handler/logger_handler.cpp
-        logger_handler/file_manager.cpp
-        )
-set(DATA_HANDLER_SOURCES
-        data_handler/data_handler.cpp
-        )
+    logger_handler/logger_manager.cpp logger_handler/logger_handler.cpp
+    logger_handler/file_manager.cpp)
+set(DATA_HANDLER_SOURCES data_handler/data_handler.cpp)
 set(COMMAND_HANDLER_SOURCES
-        command_handler/command_impl.cpp
-        command_handler/general_command_handler.cpp
-        command_handler/hap_command_handler.cpp
-        command_handler/mid360_command_handler.cpp
-        command_handler/build_request.cpp
-        command_handler/parse_lidar_state_info.cpp
-        )
+    command_handler/command_impl.cpp
+    command_handler/general_command_handler.cpp
+    command_handler/hap_command_handler.cpp
+    command_handler/mid360_command_handler.cpp
+    command_handler/build_request.cpp
+    command_handler/parse_lidar_state_info.cpp)
 set(DEBUG_POINT_CLOUD_HANDLER_SOURCES
-        debug_point_cloud_handler/debug_point_cloud_manager.cpp
-        debug_point_cloud_handler/debug_point_cloud_handler.cpp
-        )
+    debug_point_cloud_handler/debug_point_cloud_manager.cpp
+    debug_point_cloud_handler/debug_point_cloud_handler.cpp)
 
 set(LIVOX_SOURCES
-        ../3rdparty/FastCRC/FastCRC_tables.h
-        ../3rdparty/FastCRC/FastCRCsw.cpp
-        ${MAIN_SOURCES}
-        ${BASE_SOURCES}
-        ${COMM_SOURCES}
-        ${UPGRADE_SOURCES}
-        ${LOGGER_HANDLER_SOURCES}
-        ${DATA_HANDLER_SOURCES}
-        ${COMMAND_HANDLER_SOURCES}
-        ${DEBUG_POINT_CLOUD_HANDLER_SOURCES}
-        )
+    ../3rdparty/FastCRC/FastCRC_tables.h
+    ../3rdparty/FastCRC/FastCRCsw.cpp
+    ${MAIN_SOURCES}
+    ${BASE_SOURCES}
+    ${COMM_SOURCES}
+    ${UPGRADE_SOURCES}
+    ${LOGGER_HANDLER_SOURCES}
+    ${DATA_HANDLER_SOURCES}
+    ${COMMAND_HANDLER_SOURCES}
+    ${DEBUG_POINT_CLOUD_HANDLER_SOURCES})
 
-target_sources(${SDK_LIBRARY_STATIC}
-        PRIVATE
-        ${LIVOX_SOURCES}
-        )
-target_sources(${SDK_LIBRARY_SHARED}
-        PRIVATE
-        ${LIVOX_SOURCES}
-        )
+target_sources(${SDK_LIBRARY_STATIC} PRIVATE ${LIVOX_SOURCES})
+target_sources(${SDK_LIBRARY_SHARED} PRIVATE ${LIVOX_SOURCES})
 
-install(TARGETS ${SDK_LIBRARY_STATIC} ${SDK_LIBRARY_SHARED}
-        PUBLIC_HEADER DESTINATION include
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+target_link_libraries(${SDK_LIBRARY_STATIC} PUBLIC Threads::Threads)
+target_link_libraries(${SDK_LIBRARY_SHARED} PUBLIC Threads::Threads)
+
+install(
+  TARGETS ${SDK_LIBRARY_STATIC} ${SDK_LIBRARY_SHARED}
+  PUBLIC_HEADER DESTINATION include
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary
This PR upgrades the minimum required CMake version to 3.10 to avoid deprecation warnings in CMake 4.x and above. It also modernizes the CMake configuration by following current best practices.

## Changes
- **CMake Version Upgrade**: Updated `cmake_minimum_required` to 3.10 across all `CMakeLists.txt` files.
- **Threading Support**: Replaced manual `-pthread` flags and `THREADS_PTHREAD_ARG` hacks with standard `find_package(Threads REQUIRED)` and linking to `Threads::Threads`.
- **C++ Standard**: Set `CMAKE_CXX_STANDARD_REQUIRED` to `ON` and `CMAKE_CXX_EXTENSIONS` to `OFF` for consistent C++11 usage.
- **Cleanup**: Removed redundant `project()` definitions and global flag overrides in subdirectories.
- **Formatting**: Standardized the formatting of all CMake files using `cmake-format`.

These changes ensure better compatibility with newer CMake versions and more portable build behavior.
