### PR TITLE
adapt to Ubuntu 24.04.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 project(livox_sdk2)
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 project(livox_sdk2)
 

--- a/samples/debug_point_cloud/CMakeLists.txt
+++ b/samples/debug_point_cloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(DEMO_NAME debug_point_cloud)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/lidar_cmd_observer/CMakeLists.txt
+++ b/samples/lidar_cmd_observer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(DEMO_NAME lidar_cmd_observer)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_quick_start/CMakeLists.txt
+++ b/samples/livox_lidar_quick_start/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(DEMO_NAME livox_lidar_quick_start)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
+++ b/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(DEMO_NAME livox_lidar_rmc_time_sync)
 if (WIN32)

--- a/samples/logger/CMakeLists.txt
+++ b/samples/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(DEMO_NAME logger)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/multi_lidars_upgrade/CMakeLists.txt
+++ b/samples/multi_lidars_upgrade/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(DEMO_NAME multi_lidars_upgrade)
 add_executable(${DEMO_NAME} main.cpp)

--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 set(SDK_LIBRARY_STATIC livox_lidar_sdk_static)
 set(SDK_LIBRARY_SHARED livox_lidar_sdk_shared)

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -31,7 +31,7 @@
 #include <functional>
 #include <vector>
 #include <atomic>
-
+#include <cstdint>
 #include "livox_lidar_def.h"
 
 namespace livox {

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
-
+#include <cstdint>
 namespace livox {
 namespace lidar {
 


### PR DESCRIPTION
This pull request updates the minimum required CMake version across the project and sample directories, and adds missing includes for `cstdint` in some header files to ensure proper type definitions. These changes help modernize the build configuration and improve type safety.

**Build system modernization:**
* Updated `cmake_minimum_required` from version 3.0 to 3.24 in all `CMakeLists.txt` files, including the main project and all sample/demo subdirectories. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R1) [[2]](diffhunk://#diff-7d5e7fff524477259e472bf6c42b0a26419b75cc359bbb689712ec10641e32b9L1-R1) [[3]](diffhunk://#diff-0c62c1a323e8055eef41a866a41a3686b2f85f5d5852321b3f5496bd37c6341cL1-R1) [[4]](diffhunk://#diff-40212894a02712d0acaf63295bfb6b48120653febfd7f4d98c685272783156e3L1-R1) [[5]](diffhunk://#diff-79e4abcd82780c77c9deaf3c252449ae6af3228adb47ba4dd1156e4f590b6a82L1-R1) [[6]](diffhunk://#diff-3e1c6e876501f9501cec8888eaa8689d4c9cb759bc00e25d5872870c6e2c4873L1-R1) [[7]](diffhunk://#diff-bf58e7a91044b9b29f7495160cdedaf09909794ca08a36de22923270680447c8L1-R1) [[8]](diffhunk://#diff-feb74d6acfacb32b7669829bb27665c4887a04c8974ddcd405f74fdf04606f5dL1-R1) [[9]](diffhunk://#diff-79b619b0aac36921498ad681d60ecf1d0fc964281acd98fcbeb7c4e5516695e6L1-R1)

**Codebase improvements:**
* Added `#include <cstdint>` to `sdk_core/comm/define.h` and `sdk_core/logger_handler/file_manager.h` to ensure standard integer type definitions are available. [[1]](diffhunk://#diff-bea5cc8ab66b81959b6b598700c76ec17c2e6ef2f4d3e642dac54c6245aa4358L34-R34) [[2]](diffhunk://#diff-8bcd4ce4e1b5e44be2318c2e81d094bdcd916c795249a59a1790396516f604b9L31-R31)