### PR TITLE
修改cmake_minimum_required要求来适配ubuntu26.04的默认cmake4.2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(livox_sdk2)
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(livox_sdk2)
 

--- a/samples/debug_point_cloud/CMakeLists.txt
+++ b/samples/debug_point_cloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME debug_point_cloud)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/lidar_cmd_observer/CMakeLists.txt
+++ b/samples/lidar_cmd_observer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME lidar_cmd_observer)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_quick_start/CMakeLists.txt
+++ b/samples/livox_lidar_quick_start/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME livox_lidar_quick_start)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
+++ b/samples/livox_lidar_rmc_time_sync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME livox_lidar_rmc_time_sync)
 if (WIN32)

--- a/samples/logger/CMakeLists.txt
+++ b/samples/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME logger)
 add_executable(${DEMO_NAME} main.cpp)

--- a/samples/multi_lidars_upgrade/CMakeLists.txt
+++ b/samples/multi_lidars_upgrade/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(DEMO_NAME multi_lidars_upgrade)
 add_executable(${DEMO_NAME} main.cpp)

--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(SDK_LIBRARY_STATIC livox_lidar_sdk_static)
 set(SDK_LIBRARY_SHARED livox_lidar_sdk_shared)

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_FILE_MANAGER_
 #define LIVOX_FILE_MANAGER_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
修改cmake_minimum_required要求来适配ubuntu26.04的默认cmake4.2.3,其已移除cmake3.5之前的支持，直接编译会报错