### PR TITLE
Add Mid-70 LiDAR support

### DIFF
--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -110,6 +110,7 @@ set(COMMAND_HANDLER_SOURCES
         command_handler/build_request.cpp
         command_handler/parse_lidar_state_info.cpp
         command_handler/mid360s_command_handler.cpp
+        command_handler/mid70_command_handler.cpp
         )
 set(DEBUG_POINT_CLOUD_HANDLER_SOURCES
         debug_point_cloud_handler/debug_point_cloud_manager.cpp

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -221,6 +221,19 @@ static const uint16_t kMid360sHostPointCloudPort = 56301;
 static const uint16_t kMid360sHostImuDataPort    = 56401;
 static const uint16_t kMid360sHostLogPort        = 56501;
 
+static const uint16_t kMid70LidarCmdPort             = 56100;
+static const uint16_t kMid70LidarPushMsgPort         = 56200;
+static const uint16_t kMid70LidarPointCloudPort      = 56300;
+static const uint16_t kMid70LidarImuDataPort         = 56400;
+static const uint16_t kMid70LidarLogPort             = 56500;
+static const uint16_t kMid70LidarDebugPointCloudPort = 60301;
+
+static const uint16_t kMid70HostCmdPort        = 56101;
+static const uint16_t kMid70HostPushMsgPort    = 56201;
+static const uint16_t kMid70HostPointCloudPort = 56301;
+static const uint16_t kMid70HostImuDataPort    = 56401;
+static const uint16_t kMid70HostLogPort        = 56501;
+
 typedef enum {
   kCmd = 0,
   kPush = 1,

--- a/sdk_core/command_handler/build_request.cpp
+++ b/sdk_core/command_handler/build_request.cpp
@@ -161,6 +161,85 @@ bool BuildRequest::BuildUpdateMid360LidarCfgRequest(const LivoxLidarCfg& lidar_c
 
 }
 
+bool BuildRequest::BuildUpdateMid70LidarCfgRequest(const LivoxLidarCfg& lidar_cfg,
+    uint8_t* req_buf, uint16_t& req_len) {
+
+  uint16_t key_num = 3;
+  memcpy(&req_buf[req_len], &key_num, sizeof(key_num));
+  req_len = sizeof(key_num) + sizeof(uint16_t);
+
+  LivoxLidarKeyValueParam * state_kv = (LivoxLidarKeyValueParam *)&req_buf[req_len];
+  state_kv->key = static_cast<uint16_t>(kKeyStateInfoHostIpCfg);
+  state_kv->length = sizeof(uint8_t) * 8;
+  HostIpInfoValue* host_state_ip_info_val = (HostIpInfoValue*)&state_kv->value;
+  if (!InitHostIpAddr(lidar_cfg.host_net_info.host_ip, host_state_ip_info_val)) {
+    LOG_ERROR("Build update lidar cfg request failed, init host ip addr failed.");
+    return false;
+  }
+
+  if (lidar_cfg.host_net_info.multicast_ip.empty()) {
+    if (!InitHostIpAddr(lidar_cfg.host_net_info.host_ip, host_state_ip_info_val)) {
+      LOG_ERROR("Build update lidar cfg request failed, init host ip addr failed.");
+      return false;
+    }
+  } else {
+    if (!InitMulticastHostIpAddr(lidar_cfg.host_net_info.multicast_ip, host_state_ip_info_val)) {
+      LOG_ERROR("Build update lidar cfg request failed, init pointcloud multicast ip addr failed.");
+      return false;
+    }
+  }
+
+  uint16_t lidar_state_port = kMid70LidarPushMsgPort;
+  memcpy(&(host_state_ip_info_val->host_port), &lidar_cfg.host_net_info.push_msg_port, sizeof(lidar_cfg.host_net_info.push_msg_port));
+  memcpy(&(host_state_ip_info_val->lidar_port), &lidar_state_port, sizeof(lidar_state_port));
+  req_len += sizeof(LivoxLidarKeyValueParam) - sizeof(uint8_t) + sizeof(HostIpInfoValue);
+
+  LivoxLidarKeyValueParam * point_kv = (LivoxLidarKeyValueParam *)&req_buf[req_len];
+  point_kv->key = static_cast<uint16_t>(kKeyLidarPointDataHostIpCfg);
+  point_kv->length = sizeof(uint8_t) * 8;
+  HostIpInfoValue* host_point_ip_info_val = (HostIpInfoValue*)&point_kv->value;
+  if (lidar_cfg.host_net_info.multicast_ip.empty()) {
+    if (!InitHostIpAddr(lidar_cfg.host_net_info.host_ip, host_point_ip_info_val)) {
+      LOG_ERROR("Build update lidar cfg request failed, init pointcloud host ip addr failed.");
+      return false;
+    }
+  } else {
+    if (!InitMulticastHostIpAddr(lidar_cfg.host_net_info.multicast_ip, host_point_ip_info_val)) {
+      LOG_ERROR("Build update lidar cfg request failed, init pointcloud multicast ip addr failed.");
+      return false;
+    }
+  }
+
+  uint16_t lidar_point_port = kMid70LidarPointCloudPort;
+  memcpy(&(host_point_ip_info_val->host_port), &lidar_cfg.host_net_info.point_data_port, sizeof(lidar_cfg.host_net_info.point_data_port));
+  memcpy(&(host_point_ip_info_val->lidar_port), &lidar_point_port, sizeof(lidar_point_port));
+  req_len += sizeof(LivoxLidarKeyValueParam) - sizeof(uint8_t) + sizeof(HostIpInfoValue);
+
+  LivoxLidarKeyValueParam * imu_kv = (LivoxLidarKeyValueParam *)&req_buf[req_len];
+  imu_kv->key = static_cast<uint16_t>(kKeyLidarImuHostIpCfg);
+  imu_kv->length = sizeof(uint8_t) * 8;
+  HostIpInfoValue* host_imu_ip_info_val = (HostIpInfoValue*)&imu_kv->value;
+
+  if (lidar_cfg.host_net_info.multicast_ip.empty()) {
+    if (!InitHostIpAddr(lidar_cfg.host_net_info.host_ip, host_imu_ip_info_val)) {
+      LOG_ERROR("Build update lidar cfg request failed, init imu host ip addr failed.");
+      return false;
+    }
+  } else {
+    if (!InitMulticastHostIpAddr(lidar_cfg.host_net_info.multicast_ip, host_imu_ip_info_val)) {
+      LOG_ERROR("Build update lidar cfg request failed, init imu multicast ip addr failed.");
+      return false;
+    }
+  }
+
+  uint16_t lidar_imu_port = kMid70LidarImuDataPort;
+  memcpy(&(host_imu_ip_info_val->host_port), &lidar_cfg.host_net_info.imu_data_port, sizeof(lidar_cfg.host_net_info.imu_data_port));
+  memcpy(&(host_imu_ip_info_val->lidar_port), &lidar_imu_port, sizeof(lidar_imu_port));
+  req_len += sizeof(LivoxLidarKeyValueParam) - sizeof(uint8_t) + sizeof(HostIpInfoValue);
+  return true;
+
+}
+
 bool BuildRequest::BuildUpdateLidarCfgRequest(const LivoxLidarCfg& lidar_cfg,
     uint8_t* req_buf, uint16_t& req_len) {
   
@@ -199,6 +278,8 @@ bool BuildRequest::BuildUpdateLidarCfgRequest(const LivoxLidarCfg& lidar_cfg,
     lidar_point_port = kPaLidarPointCloudPort;
   } else if (lidar_cfg.device_type == kLivoxLidarTypeMid360s) {
       lidar_point_port = kMid360sLidarPointCloudPort;
+  } else if (lidar_cfg.device_type == kLivoxLidarTypeMid70) {
+      lidar_point_port = kMid70LidarPointCloudPort;
   }
   else {
     LOG_ERROR("Build update lidar cfg request failed, unknown the dev_type:{}", lidar_cfg.device_type);
@@ -236,6 +317,8 @@ bool BuildRequest::BuildUpdateLidarCfgRequest(const LivoxLidarCfg& lidar_cfg,
     lidar_imu_port = kMid360LidarImuDataPort;
   } else if (lidar_cfg.device_type == kLivoxLidarTypeMid360s) {
     lidar_imu_port = kMid360sLidarImuDataPort;
+  } else if (lidar_cfg.device_type == kLivoxLidarTypeMid70) {
+    lidar_imu_port = kMid70LidarImuDataPort;
   }
   else {
     LOG_ERROR("Build update lidar cfg request failed, unknown the dev_type:{}", lidar_cfg.device_type);

--- a/sdk_core/command_handler/build_request.h
+++ b/sdk_core/command_handler/build_request.h
@@ -49,6 +49,7 @@ class BuildRequest {
   static bool BuildUpdateViewLidarCfgRequest(const ViewLidarIpInfo& view_lidar_info, uint8_t* req_buf, uint16_t& req_len);
   static bool BuildUpdateLidarCfgRequest(const LivoxLidarCfg& lidar_cfg, uint8_t* req_buf, uint16_t& req_len);
   static bool BuildUpdateMid360LidarCfgRequest(const LivoxLidarCfg& lidar_cfg, uint8_t* req_buf, uint16_t& req_len);
+  static bool BuildUpdateMid70LidarCfgRequest(const LivoxLidarCfg& lidar_cfg, uint8_t* req_buf, uint16_t& req_len);
   static bool BuildSetLidarIPInfoRequest(const LivoxLidarIpInfo& ip_config, uint8_t* req_buf, uint16_t& req_len);
   static bool BuildSetHostStateInfoIPCfgRequest(const HostStateInfoIpInfo& host_state_info_ipcfg, uint8_t* req_buf, uint16_t& req_len);
   static bool BuildSetHostPointDataIPInfoRequest(const HostPointIPInfo& lidar_ip_config, uint8_t* req_buf, uint16_t& req_len);

--- a/sdk_core/command_handler/general_command_handler.cpp
+++ b/sdk_core/command_handler/general_command_handler.cpp
@@ -31,6 +31,7 @@
 #include "command_handler/hap_command_handler.h"
 #include "command_handler/mid360_command_handler.h"
 #include "command_handler/mid360s_command_handler.h"
+#include "command_handler/mid70_command_handler.h"
 #include "logger_handler/logger_manager.h"
 #include "debug_point_cloud_handler/debug_point_cloud_manager.h"
 #include "base/logging.h"
@@ -80,6 +81,9 @@ bool GeneralCommandHandler::Init(std::shared_ptr<std::vector<LivoxLidarCfg>>& cu
   }
   if (lidars_command_handler_.find(kLivoxLidarTypeMid360s) == lidars_command_handler_.end()) {
     lidars_command_handler_[kLivoxLidarTypeMid360s].reset(new Mid360sCommandHandler(device_manager_));
+  }
+  if (lidars_command_handler_.find(kLivoxLidarTypeMid70) == lidars_command_handler_.end()) {
+    lidars_command_handler_[kLivoxLidarTypeMid70].reset(new Mid70CommandHandler(device_manager_));
   }
   AddDetectedLidar(custom_lidars_cfg_ptr);
   return true;
@@ -290,6 +294,10 @@ void GeneralCommandHandler::CreateCommandHandler(const uint8_t dev_type) {
       if (!(lidars_command_handler_[dev_type]->Init(custom_lidars_cfg_map_))) {
         LOG_ERROR("General command handler init failed, the lidar of type:{} command init failed.", dev_type);
       }
+    } else if (dev_type == kLivoxLidarTypeMid70) {
+      if (!(lidars_command_handler_[dev_type]->Init(custom_lidars_cfg_map_))) {
+        LOG_ERROR("General command handler init failed, the lidar of type:{} command init failed.", dev_type);
+      }
     }
     
     return;
@@ -312,7 +320,13 @@ void GeneralCommandHandler::CreateCommandHandler(const uint8_t dev_type) {
       }
     } else if (dev_type == kLivoxLidarTypeMid360s) {
       std::shared_ptr<Mid360sCommandHandler> mid360s_command_handler_ptr(new Mid360sCommandHandler(device_manager_));
-      lidars_command_handler_[dev_type] = mid360s_command_handler_ptr;        
+      lidars_command_handler_[dev_type] = mid360s_command_handler_ptr;
+      if (!(lidars_command_handler_[dev_type]->Init(is_view_))) {
+        LOG_ERROR("General command handler init failed, the lidar of type:{} command init failed.", dev_type);
+      }
+    } else if (dev_type == kLivoxLidarTypeMid70) {
+      std::shared_ptr<Mid70CommandHandler> mid70_command_handler_ptr(new Mid70CommandHandler(device_manager_));
+      lidars_command_handler_[dev_type] = mid70_command_handler_ptr;
       if (!(lidars_command_handler_[dev_type]->Init(is_view_))) {
         LOG_ERROR("General command handler init failed, the lidar of type:{} command init failed.", dev_type);
       }
@@ -695,8 +709,43 @@ bool GeneralCommandHandler::GetQueryLidarInternalInfoKeys(const uint32_t handle,
       };
       key_sets.swap(tmp_key_sets);
       return true;
+    } else if (dev_type == kLivoxLidarTypeMid70){
+      std::set<ParamKeyName> tmp_key_sets {
+        kKeyPclDataType,
+        kKeyPatternMode,
+        kKeyLidarIpCfg,
+        kKeyStateInfoHostIpCfg,
+        kKeyLidarPointDataHostIpCfg,
+        kKeyLidarImuHostIpCfg,
+        kKeyInstallAttitude,
+        kKeyFovCfg0,
+        kKeyFovCfg1,
+        kKeyFovCfgEn,
+        kKeyDetectMode,
+        kKeyFuncIoCfg,
+        kKeyWorkMode,
+        kKeyImuDataEn,
+        kKeySn,
+        kKeyProductInfo,
+        kKeyVersionApp,
+        kKeyVersionLoader,
+        kKeyVersionHardware,
+        kKeyMac,
+        kKeyCurWorkState,
+        kKeyCoreTemp,
+        kKeyPowerUpCnt,
+        kKeyLocalTimeNow,
+        kKeyLastSyncTime,
+        kKeyTimeOffset,
+        kKeyTimeSyncType,
+        kKeyLidarDiagStatus,
+        kKeyFwType,
+        kKeyHmsCode
+      };
+      key_sets.swap(tmp_key_sets);
+      return true;
     }
-    
+
   }
   return false;
 }
@@ -810,4 +859,3 @@ void GeneralCommandHandler::CommandsHandle(TimePoint now) {
 
 }  // namespace livox
 } // namespace lidar
-

--- a/sdk_core/command_handler/mid70_command_handler.cpp
+++ b/sdk_core/command_handler/mid70_command_handler.cpp
@@ -1,0 +1,285 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Livox. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include "mid70_command_handler.h"
+#include "livox_lidar_def.h"
+
+#include "base/command_callback.h"
+
+#include "base/logging.h"
+#include "comm/protocol.h"
+#include "comm/generate_seq.h"
+
+#include "build_request.h"
+#include "general_command_handler.h"
+
+#include "parse_lidar_state_info.h"
+
+namespace livox {
+namespace lidar {
+
+Mid70CommandHandler::Mid70CommandHandler(DeviceManager* device_manager)
+    : CommandHandler(device_manager),
+      comm_port_(new CommPort),
+      is_view_(false) {
+}
+
+bool Mid70CommandHandler::Init(bool is_view) {
+  is_view_ = is_view;
+  return true;
+}
+
+bool Mid70CommandHandler::Init(const std::map<uint32_t, LivoxLidarCfg>& custom_lidars_cfg_map) {
+  for (const auto& it : custom_lidars_cfg_map) {
+    if (it.second.device_type == kLivoxLidarTypeMid70 && custom_lidars_.find(it.first) == custom_lidars_.end()) {
+      custom_lidars_[it.first] = it.second;
+    }
+  }
+  return true;
+}
+
+void Mid70CommandHandler::Handle(const uint32_t handle, uint16_t lidar_port, const Command& command) {
+  if (command.packet.cmd_type == kCommandTypeAck) {
+    LOG_INFO(" Receive Ack: Id {} Seq {}", command.packet.cmd_id, command.packet.seq_num);
+    OnCommandAck(handle, command);
+  } else if (command.packet.cmd_type == kCommandTypeCmd) {
+    LOG_INFO(" Receive Command: Id {} Seq {}", command.packet.cmd_id, command.packet.seq_num);
+    OnCommandCmd(handle, lidar_port, command);
+  }
+}
+
+void Mid70CommandHandler::OnCommandAck(uint32_t handle, const Command &command) {
+  if (command.cb == nullptr) {
+    return;
+  }
+
+  if (command.packet.data == nullptr) {
+    (*command.cb)(kLivoxLidarStatusTimeout, handle, command.packet.data);
+    return;
+  }
+
+  (*command.cb)(kLivoxLidarStatusSuccess, handle, command.packet.data);
+}
+
+void Mid70CommandHandler::OnCommandCmd(uint32_t handle, const uint16_t lidar_port, const Command &command) {
+  if (command.packet.cmd_id == kCommandIDLidarPushMsg && lidar_port == kMid70LidarPushMsgPort) {
+    std::string info;
+    ParseLidarStateInfo::Parse(command.packet, info);
+    GeneralCommandHandler::GetInstance().PushLivoxLidarInfo(handle, info);
+  }
+}
+
+void Mid70CommandHandler::UpdateLidarCfg(const ViewLidarIpInfo& view_lidar_info) {
+  {
+    std::lock_guard<std::mutex> lock(device_mutex_);
+    if (devices_.find(view_lidar_info.handle) != devices_.end()) {
+      return;
+    }
+  }
+  SetViewLidar(view_lidar_info);
+}
+
+void Mid70CommandHandler::UpdateLidarCfg(const uint32_t handle, const uint16_t lidar_cmd_port) {
+  {
+    std::lock_guard<std::mutex> lock(device_mutex_);
+    if (devices_.find(handle) != devices_.end()) {
+      return;
+    }
+  }
+
+  if (custom_lidars_.find(handle) != custom_lidars_.end()) {
+    const LivoxLidarCfg& lidar_cfg = custom_lidars_[handle];
+    SetCustomLidar(handle, lidar_cmd_port, lidar_cfg);
+    return;
+  }
+}
+
+void Mid70CommandHandler::SetViewLidar(const ViewLidarIpInfo& view_lidar_info) {
+  uint8_t req_buff[kMaxCommandBufferSize] = {0};
+  uint16_t req_len = 0;
+  if (!BuildRequest::BuildUpdateViewLidarCfgRequest(view_lidar_info, req_buff, req_len)) {
+    LOG_ERROR("Build update view lidar cfg request failed.");
+    return;
+  }
+
+  struct in_addr addr;
+  addr.s_addr = view_lidar_info.handle;
+  std::string lidar_ip = inet_ntoa(addr);
+  uint16_t seq = GenerateSeq::GetSeq();
+  Command command(seq, kCommandIDLidarWorkModeControl, kCommandTypeCmd, kHostSend, req_buff, req_len, view_lidar_info.handle,
+      lidar_ip, MakeCommandCallback<LivoxLidarAsyncControlResponse>(Mid70CommandHandler::UpdateLidarCallback, this));
+  SendCommand(command, view_lidar_info.lidar_cmd_port);
+}
+
+void Mid70CommandHandler::SetCustomLidar(const uint32_t handle, const uint16_t lidar_cmd_port, const LivoxLidarCfg& lidar_cfg) {
+  uint8_t req_buff[kMaxCommandBufferSize] = {0};
+  uint16_t req_len = 0;
+  if (!BuildRequest::BuildUpdateMid70LidarCfgRequest(lidar_cfg, req_buff, req_len)) {
+    LOG_ERROR("Build update lidar cfg request failed.");
+    return;
+  }
+
+  struct in_addr addr;
+  addr.s_addr = handle;
+  std::string lidar_ip = inet_ntoa(addr);
+  uint16_t seq = GenerateSeq::GetSeq();
+  Command command(seq, kCommandIDLidarWorkModeControl, kCommandTypeCmd, kHostSend, req_buff, req_len, handle,
+      lidar_ip, MakeCommandCallback<LivoxLidarAsyncControlResponse>(Mid70CommandHandler::UpdateLidarCallback, this));
+  SendCommand(command, lidar_cmd_port);
+}
+
+void Mid70CommandHandler::UpdateLidarCallback(livox_status status, uint32_t handle,
+    LivoxLidarAsyncControlResponse *response, void *client_data) {
+  if (status != kLivoxLidarStatusSuccess) {
+    LOG_INFO("Update lidar failed, the status:{}", status);
+    return;
+  }
+
+  if (response == nullptr) {
+    LOG_ERROR("Update lidar failed, the handle:{}, status:{}, response is nullptr.", handle, status);
+    return;
+  }
+
+  if (response->ret_code == 0 && response->error_key == 0) {
+    if (client_data != nullptr) {
+      Mid70CommandHandler* self = (Mid70CommandHandler*)client_data;
+      self->AddDevice(handle);
+    }
+    LOG_INFO("Update lidar:{} succ.", handle);
+    GeneralCommandHandler::GetInstance().LivoxLidarInfoChange(handle);
+  } else {
+    LOG_ERROR("Update lidar failed, the ret_code:{}, error_key:{}", response->ret_code, response->error_key);
+  }
+}
+
+void Mid70CommandHandler::AddDevice(const uint32_t handle) {
+  std::lock_guard<std::mutex> lock(device_mutex_);
+  devices_.insert(handle);
+}
+
+bool Mid70CommandHandler::IsStatusException(const Command &command) {
+  if (!command.packet.data) {
+    return false;
+  }
+
+  if (command.packet.cmd_id != kCommandIDLidarWorkModeControl) {
+    return false;
+  }
+
+  LivoxLidarAsyncControlResponse* data = (LivoxLidarAsyncControlResponse*)(command.packet.data);
+  if (data->ret_code != 0) {
+    return false;
+  }
+  return true;
+}
+
+livox_status Mid70CommandHandler::SendCommand(const Command &command, const uint16_t lidar_cmd_port) {
+  if (command.packet.cmd_type == kCommandTypeAck) {
+    return kLivoxLidarStatusFailure;
+  }
+
+  GeneralCommandHandler::GetInstance().AddCommand(command);
+
+  std::vector<uint8_t> buf(kMaxCommandBufferSize + 1);
+  int size = 0;
+  comm_port_->Pack(buf.data(), kMaxCommandBufferSize, (uint32_t *)&size, command.packet);
+
+
+  struct sockaddr_in servaddr;
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = inet_addr(command.lidar_ip.c_str());
+  servaddr.sin_port = htons(lidar_cmd_port);
+
+  int byte_send = device_manager_->SendCommand(kLivoxLidarTypeMid70, command.handle, buf, size, (const struct sockaddr *) &servaddr, sizeof(servaddr));
+  if (byte_send < 0) {
+    LOG_ERROR("Sent cmd to lidar failed, the send_byte:{}, cmd_id:{}, seq:{}, lidar_ip:{}",
+        byte_send, command.packet.cmd_id, command.packet.seq_num, command.lidar_ip.c_str());
+    if (command.cb) {
+      (*command.cb)(kLivoxLidarStatusSendFailed, command.handle, nullptr);
+    }
+    return kLivoxLidarStatusSendFailed;
+  }
+  return kLivoxLidarStatusSuccess;
+}
+
+livox_status Mid70CommandHandler::SendCommand(const Command &command) {
+  if (command.packet.cmd_type == kCommandTypeAck) {
+    return kLivoxLidarStatusFailure;
+  }
+
+  std::vector<uint8_t> buf(kMaxCommandBufferSize + 1);
+  int size = 0;
+  comm_port_->Pack(buf.data(), kMaxCommandBufferSize, (uint32_t *)&size, command.packet);
+
+  struct sockaddr_in servaddr;
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = inet_addr(command.lidar_ip.c_str());
+  servaddr.sin_port = htons(kMid70LidarCmdPort);
+
+  int byte_send = device_manager_->SendCommand(kLivoxLidarTypeMid70, command.handle, buf, size, (const struct sockaddr *) &servaddr, sizeof(servaddr));
+  if (byte_send < 0) {
+    LOG_ERROR("Sent cmd to lidar failed, the send_byte:{}, cmd_id:{}, seq:{}, lidar_ip:{}",
+        byte_send, command.packet.cmd_id, command.packet.seq_num, command.lidar_ip.c_str());
+    if (command.cb) {
+      (*command.cb)(kLivoxLidarStatusSendFailed, command.handle, nullptr);
+    }
+    return kLivoxLidarStatusSendFailed;
+  }
+  return kLivoxLidarStatusSuccess;
+}
+
+livox_status Mid70CommandHandler::SendLoggerCommand(const Command &command) {
+  if (command.packet.cmd_type == kCommandTypeAck) {
+    return kLivoxLidarStatusFailure;
+  }
+
+  std::vector<uint8_t> buf(kMaxCommandBufferSize + 1);
+  int size = 0;
+  comm_port_->Pack(buf.data(), kMaxCommandBufferSize, (uint32_t *)&size, command.packet);
+
+  struct sockaddr_in servaddr;
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = inet_addr(command.lidar_ip.c_str());
+  servaddr.sin_port = htons(kMid70LidarLogPort);
+
+  int byte_send = device_manager_->SendLoggerCommand(kLivoxLidarTypeMid70, command.handle, buf, size, (const struct sockaddr *) &servaddr, sizeof(servaddr));
+  if (byte_send < 0) {
+    LOG_ERROR("Sent cmd to lidar failed, the send_byte:{}, cmd_id:{}, seq:{}, lidar_ip:{}",
+        byte_send, command.packet.cmd_id, command.packet.seq_num, command.lidar_ip.c_str());
+    if (command.cb) {
+      (*command.cb)(kLivoxLidarStatusSendFailed, command.handle, nullptr);
+    }
+    return kLivoxLidarStatusSendFailed;
+  }
+  return kLivoxLidarStatusSuccess;
+}
+
+
+bool Mid70CommandHandler::GetHostInfo(const uint32_t handle, std::string& host_ip, uint16_t& cmd_port) {
+  return true;
+}
+
+
+}  // namespace livox
+} // namespace lidar

--- a/sdk_core/command_handler/mid70_command_handler.h
+++ b/sdk_core/command_handler/mid70_command_handler.h
@@ -1,0 +1,90 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Livox. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef MID70_COMMAND_HANDLER_H_
+#define MID70_COMMAND_HANDLER_H_
+
+#include <memory>
+#include <map>
+#include <list>
+#include <mutex>
+
+#include "base/command_callback.h"
+#include "base/io_thread.h"
+
+#include "comm/protocol.h"
+#include "comm/comm_port.h"
+#include "comm/define.h"
+
+#include "livox_lidar_def.h"
+#include "device_manager.h"
+
+#include "command_handler.h"
+
+namespace livox {
+namespace lidar {
+
+class Mid70CommandHandler : public CommandHandler {
+ public:
+  Mid70CommandHandler(DeviceManager* device_manager);
+  ~Mid70CommandHandler() {}
+  virtual bool Init(bool is_view);
+
+  virtual bool Init(const std::map<uint32_t, LivoxLidarCfg>& custom_lidars_cfg_map);
+  virtual void Handle(const uint32_t handle, uint16_t lidar_port, const Command& command);
+  virtual void UpdateLidarCfg(const ViewLidarIpInfo& view_lidar_info);
+  virtual void UpdateLidarCfg(const uint32_t handle, const uint16_t lidar_cmd_port);
+  virtual livox_status SendCommand(const Command& command);
+  virtual livox_status SendLoggerCommand(const Command &command);
+
+  static void UpdateLidarCallback(livox_status status, uint32_t handle, LivoxLidarAsyncControlResponse *response, void *client_data);
+  void AddDevice(const uint32_t handle);
+ private:
+  void SetCustomLidar(const uint32_t handle, const uint16_t lidar_cmd_port, const LivoxLidarCfg& lidar_cfg);
+  void SetViewLidar(const ViewLidarIpInfo& view_lidar_info);
+  livox_status SendCommand(const Command &command, const uint16_t lidar_cmd_port);
+
+
+  bool GetHostInfo(const uint32_t handle, std::string& host_ip, uint16_t& cmd_port);
+
+  void CommandsHandle(TimePoint now);
+
+  void OnCommand(uint32_t handle, const Command &command);
+  void OnCommandAck(const uint32_t handle, const Command &command);
+  void OnCommandCmd(const uint32_t handle, const uint16_t lidar_port, const Command &command);
+  bool IsStatusException(const Command &command);
+  void QueryDiagnosisInfo(uint32_t handle);
+  void OnLidarInfoChange(const Command &command);
+ private:
+  std::unique_ptr<CommPort> comm_port_;
+  std::mutex device_mutex_;
+  std::set<uint32_t> devices_;
+  std::map<uint32_t, LivoxLidarCfg> custom_lidars_;
+  bool is_view_;
+};
+
+}  // namespace livox
+} // namespace lidar
+
+#endif  // MID70_COMMAND_HANDLER_H_

--- a/sdk_core/device_manager.cpp
+++ b/sdk_core/device_manager.cpp
@@ -327,6 +327,7 @@ bool DeviceManager::CreateCommandChannel(const uint8_t dev_type, const HostNetIn
 #ifdef WIN32
 #else
   if (dev_type == kLivoxLidarTypeMid360 || dev_type == kLivoxLidarTypeMid360s) {
+  if (dev_type == kLivoxLidarTypeMid360 || dev_type == kLivoxLidarTypeMid360s || dev_type == kLivoxLidarTypeMid70) {
     socket_t broadcast_socket = util::CreateSocket(host_net_info.push_msg_port, true, true, true, "255.255.255.255", "");
     if (broadcast_socket < 0) {
       LOG_ERROR("Create broadcast socket failed.");
@@ -698,6 +699,11 @@ void DeviceManager::AddViewLidar(const uint32_t handle, LivoxLidarDiagInternalIn
   if (view_lidar_info_ptr->dev_type == kLivoxLidarTypeMid360s) {
     view_lidar_info_ptr->lidar_point_port = kMid360sLidarPointCloudPort;
     view_lidar_info_ptr->lidar_imu_data_port = kMid360sLidarImuDataPort;
+  }
+
+  if (view_lidar_info_ptr->dev_type == kLivoxLidarTypeMid70) {
+    view_lidar_info_ptr->lidar_point_port = kMid70LidarPointCloudPort;
+    view_lidar_info_ptr->lidar_imu_data_port = kMid70LidarImuDataPort;
   }
 
   CreateViewDataChannel(*view_lidar_info_ptr);

--- a/sdk_core/device_manager.cpp
+++ b/sdk_core/device_manager.cpp
@@ -326,7 +326,6 @@ bool DeviceManager::CreateCommandChannel(const uint8_t dev_type, const HostNetIn
 
 #ifdef WIN32
 #else
-  if (dev_type == kLivoxLidarTypeMid360 || dev_type == kLivoxLidarTypeMid360s) {
   if (dev_type == kLivoxLidarTypeMid360 || dev_type == kLivoxLidarTypeMid360s || dev_type == kLivoxLidarTypeMid70) {
     socket_t broadcast_socket = util::CreateSocket(host_net_info.push_msg_port, true, true, true, "255.255.255.255", "");
     if (broadcast_socket < 0) {

--- a/sdk_core/params_check.cpp
+++ b/sdk_core/params_check.cpp
@@ -146,7 +146,7 @@ void ParamsCheck::CheckLidarPort() {
 }
 
 void ParamsCheck::CheckPort(const uint8_t dev_type, LivoxLidarNetInfo& lidar_net_info) {
-  if (dev_type != kLivoxLidarTypeMid360 && dev_type != kLivoxLidarTypeMid360s) {
+  if (dev_type != kLivoxLidarTypeMid360 && dev_type != kLivoxLidarTypeMid360s && dev_type != kLivoxLidarTypeMid70) {
     return;
   }
 
@@ -203,10 +203,36 @@ void ParamsCheck::CheckPort(const uint8_t dev_type, LivoxLidarNetInfo& lidar_net
       lidar_net_info.log_data_port = kMid360sLidarLogPort;
     }
   }
-  
+
+  if (dev_type == kLivoxLidarTypeMid70) {
+    if (lidar_net_info.cmd_data_port != kMid70LidarCmdPort) {
+      LOG_ERROR("Mid70 lidar command data port must be {}", kMid70LidarCmdPort);
+      lidar_net_info.cmd_data_port = kMid70LidarCmdPort;
+    }
+
+    if (lidar_net_info.push_msg_port != kMid70LidarPushMsgPort) {
+      LOG_ERROR("Mid70 lidar push msg port must be {}", kMid70LidarPushMsgPort);
+      lidar_net_info.push_msg_port = kMid70LidarPushMsgPort;
+    }
+
+    if (lidar_net_info.point_data_port != kMid70LidarPointCloudPort) {
+      LOG_ERROR("Mid70 lidar point cloud port must be {}", kMid70LidarPointCloudPort);
+      lidar_net_info.point_data_port = kMid70LidarPointCloudPort;
+    }
+
+    if (lidar_net_info.imu_data_port != kMid70LidarImuDataPort) {
+      LOG_ERROR("Mid70 lidar imu data port must be {}", kMid70LidarImuDataPort);
+      lidar_net_info.imu_data_port = kMid70LidarImuDataPort;
+    }
+
+    if (lidar_net_info.log_data_port != kMid70LidarLogPort) {
+      LOG_ERROR("Mid70 lidar log port must be {}", kMid70LidarLogPort);
+      lidar_net_info.log_data_port = kMid70LidarLogPort;
+    }
+  }
+
 }
 
 } // namespace lidar
 } // namespace livox
-
 

--- a/sdk_core/parse_cfg_file.cpp
+++ b/sdk_core/parse_cfg_file.cpp
@@ -33,7 +33,8 @@ namespace lidar {
 const std::map<std::string, LivoxLidarDeviceType> dev_type_map = {
   {"HAP",     kLivoxLidarTypeIndustrialHAP},
   {"MID360",  kLivoxLidarTypeMid360},
-  {"Mid360s",  kLivoxLidarTypeMid360s}
+  {"Mid360s",  kLivoxLidarTypeMid360s},
+  {"MID70",   kLivoxLidarTypeMid70}
 };
 
 
@@ -156,6 +157,19 @@ bool ParseCfgFile::Parse(std::shared_ptr<std::vector<LivoxLidarCfg>>& lidars_cfg
     
       uint8_t device_type = dev_type_map.at("Mid360s");    
       const rapidjson::Value &object = doc["Mid360s"];
+
+      if (!ParseLidarCfg(object, device_type, lidars_cfg_ptr, custom_lidars_cfg_ptr)) {
+        if (raw_file) {
+          std::fclose(raw_file);
+      }
+      return false;
+    }
+  }
+
+  if (doc.HasMember("MID70") && doc["MID70"].IsObject()) {
+
+      uint8_t device_type = dev_type_map.at("MID70");
+      const rapidjson::Value &object = doc["MID70"];
 
       if (!ParseLidarCfg(object, device_type, lidars_cfg_ptr, custom_lidars_cfg_ptr)) {
         if (raw_file) {


### PR DESCRIPTION
## Summary

Add full runtime support for Mid-70 LiDAR to Livox-SDK2. Mid-70 (`kLivoxLidarTypeMid70 = 6`) was already defined in the device type enum but lacked runtime infrastructure.

## Changes

### New files
- `sdk_core/command_handler/mid70_command_handler.h` — Mid-70 command handler
- `sdk_core/command_handler/mid70_command_handler.cpp` — Full implementation

### Modified files
- `sdk_core/comm/define.h` — `kMid70Lidar*Port` / `kMid70Host*Port` constants
- `sdk_core/command_handler/build_request.h/.cpp` — `BuildUpdateMid70LidarCfgRequest()` + branches
- `sdk_core/command_handler/general_command_handler.cpp` — Register Mid-70 in Init/CreateCommandHandler/GetQueryLidarInternalInfoKeys
- `sdk_core/device_manager.cpp` — Broadcast socket + view port overrides
- `sdk_core/params_check.cpp` — Port validation
- `sdk_core/parse_cfg_file.cpp` — `"MID70"` in dev_type_map + config section
- `sdk_core/CMakeLists.txt` — Build mid70_command_handler.cpp