### PR TITLE
Fix build with GCC 13+ by force-including <cstdint>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CMAKE_CROSSCOMPILING)
 endif()
 
 if (UNIX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -include cstdint")
 endif(UNIX)
 
 add_subdirectory(sdk_core)


### PR DESCRIPTION
## Problem

Building on Ubuntu 24.04 with GCC 13 fails:

```
sdk_core/logger_handler/file_manager.h:35:1: error: 'uint64_t' does not name a type
   35 | uint64_t GetDirTotalSize(const std::string& dir_name);
sdk_core/comm/define.h:248:8: error: 'uint8_t' in namespace 'std' does not name a type
  248 |   std::uint8_t  dev_type;
```

GCC 13 / libstdc++ no longer transitively includes `<cstdint>` through other standard headers. Many `sdk_core` sources use fixed-width integer types (`uint8_t`, `uint64_t`, `std::uint8_t`, ...) without including `<cstdint>` directly, so they now fail to compile. ~47 files are affected.

## Fix

Add `-include cstdint` to the UNIX `CMAKE_CXX_FLAGS` so the header is force-included into every translation unit. This fixes the build in one line without patching dozens of vendored source files. Windows builds are unaffected (the flag is inside the existing `if (UNIX)` block).

## Testing

`cmake .. && make -j` now completes cleanly with GCC 13.3.0 — both libraries and all sample executables build with no errors.

## Similar PRs

Several open PRs address the same missing-`<cstdint>` / GCC 13+ build error. They fix it by adding `#include <cstdint>` to individual source files; this PR instead resolves it with a single compiler flag, avoiding edits to dozens of vendored files:

- #83 — Fix build error with GCC 13.2.0 (adds the `<cstdint>` include)
- #85 — Add missing includes for ubuntu 24.04 compatibility (closes #76)
- #91 — fix: added import for stdint to solve build error
- #100 — fix for unit_xx error (same `std::uint8_t` error, plus a CMake < 3.5 warning)
- #98 — Add cmake installation instructions (first commit is the same fix as #83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)